### PR TITLE
gemspec: drop rubyforge_project, it is EOL

### DIFF
--- a/localizable_model.gemspec
+++ b/localizable_model.gemspec
@@ -13,8 +13,6 @@ Gem::Specification.new do |s|
   s.description = "LocalizableModel provides localization support for " \
                   "ActiveRecord objects"
 
-  s.rubyforge_project = "."
-
   s.required_ruby_version = ">= 1.9.2"
 
   s.files = Dir[


### PR DESCRIPTION
The RubyGems property rubyforge_project is removed without a replacement.