### PR TITLE
fix: upsert localizations to avoid duplicate-key races

### DIFF
--- a/lib/localizable_model/active_record_extension.rb
+++ b/lib/localizable_model/active_record_extension.rb
@@ -33,8 +33,8 @@ module LocalizableModel
       has_many(:localizations,
                as: :localizable,
                dependent: :destroy,
-               autosave: true)
-      before_save :cleanup_localizations!
+               autosave: false)
+      after_save :save_localizations!
     end
   end
 end

--- a/lib/localizable_model/instance_methods.rb
+++ b/lib/localizable_model/instance_methods.rb
@@ -106,11 +106,10 @@ module LocalizableModel
       @localizer ||= Localizer.new(self)
     end
 
-    # Callback for cleaning up empty localizations.
-    # This is performed automatically when the model is saved.
+    # Persists localizations after the model is saved.
     #
-    def cleanup_localizations!
-      localizer.cleanup_localizations!
+    def save_localizations!
+      localizer.save_localizations!
     end
 
     def respond_to_missing?(method_name, include_private = false)

--- a/lib/localizable_model/localizer.rb
+++ b/lib/localizable_model/localizer.rb
@@ -53,11 +53,53 @@ module LocalizableModel
       get(attribute).value?
     end
 
-    def cleanup_localizations!
-      @model.localizations = @model.localizations.select(&:value?)
+    def save_localizations!
+      records    = @model.localizations.target
+      removable  = records.select { |l| l.persisted? && !l.value? }
+      upsertable = records.select { |l| upsertable?(l) }
+      return if removable.empty? && upsertable.empty?
+
+      delete_localizations(removable)
+      upsert_localizations(upsertable)
+      @model.association(:localizations).reset
+      touch_localizable
     end
 
     private
+
+    def upsertable?(localization)
+      localization.value? &&
+        (localization.new_record? || localization.value_changed?)
+    end
+
+    def delete_localizations(records)
+      ids = records.map(&:id)
+      Localization.where(id: ids).delete_all if ids.any?
+    end
+
+    def upsert_localizations(records)
+      return if records.empty?
+
+      Localization.upsert_all( # rubocop:disable Rails/SkipsModelValidations
+        records.map { |l| localization_row(l) },
+        unique_by: %i[localizable_id localizable_type name locale]
+      )
+    end
+
+    def localization_row(localization)
+      { localizable_id: @model.id,
+        localizable_type: @model.class.polymorphic_name,
+        name: localization.name,
+        locale: localization.locale,
+        value: localization.value }
+    end
+
+    def touch_localizable
+      return if @model.previously_new_record?
+      return if @model.saved_changes.except("created_at", "updated_at").any?
+
+      @model.touch # rubocop:disable Rails/SkipsModelValidations
+    end
 
     def attribute_names
       @configuration.attributes.keys.map(&:to_s)

--- a/lib/rails/generators/localizable_model/migration/templates/create_localizations.rb
+++ b/lib/rails/generators/localizable_model/migration/templates/create_localizations.rb
@@ -8,8 +8,8 @@ class CreateLocalizations < ActiveRecord::Migration
       t.string :locale
       t.text :value, limit: 16_777_215
       t.timestamps null: false
-      t.index(%i[localizable_id localizable_type name locale],
-              name: "index_localizations_on_locale")
+      t.index %i[localizable_id localizable_type name locale],
+              name: "index_localizations_on_locale", unique: true
       t.index %i[localizable_id localizable_type]
     end
   end

--- a/spec/internal/db/migrate/20160506141709_create_localizations.rb
+++ b/spec/internal/db/migrate/20160506141709_create_localizations.rb
@@ -8,8 +8,8 @@ class CreateLocalizations < ActiveRecord::Migration[4.2]
       t.string :locale
       t.text :value, limit: 16_777_215
       t.timestamps null: false
-      t.index(%i[localizable_id localizable_type name locale],
-              name: "index_localizations_on_locale")
+      t.index %i[localizable_id localizable_type name locale],
+              name: "index_localizations_on_locale", unique: true
       t.index %i[localizable_id localizable_type]
     end
   end

--- a/spec/internal/db/schema.rb
+++ b/spec/internal/db/schema.rb
@@ -23,7 +23,7 @@ ActiveRecord::Schema.define(version: 2016_05_06_141709) do
     t.text "value"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["localizable_id", "localizable_type", "name", "locale"], name: "index_localizations_on_locale"
+    t.index ["localizable_id", "localizable_type", "name", "locale"], name: "index_localizations_on_locale", unique: true
     t.index ["localizable_id", "localizable_type"], name: "index_localizations_on_localizable_id_and_localizable_type"
   end
 

--- a/spec/models/localizable_persistence_spec.rb
+++ b/spec/models/localizable_persistence_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "LocalizablePersistence" do
+  describe "when a localization already exists for the same key" do
+    let(:page) { Page.create(locale: "en") }
+
+    before do
+      page.localizations.load
+      Localization.create!(
+        localizable_id: page.id,
+        localizable_type: "Page",
+        name: "name",
+        locale: "en",
+        value: "First"
+      )
+    end
+
+    it "upserts instead of raising RecordNotUnique" do
+      page.name = "Second"
+      expect { page.save! }.not_to raise_error
+    end
+
+    it "keeps the latest value" do
+      page.update!(name: "Second")
+      expect(page.reload.name.to_s).to eq("Second")
+    end
+
+    it "does not insert a duplicate" do
+      page.update!(name: "Second")
+      expect(
+        Localization.where(localizable: page, name: "name", locale: "en").count
+      ).to eq(1)
+    end
+  end
+
+  describe "saving multiple locales at once" do
+    let(:page) do
+      Page.create(name: { "en" => "Title", "nb" => "Tittel" }, locale: "en")
+    end
+
+    it "persists the english locale" do
+      expect(page.reload.localize("en").name.to_s).to eq("Title")
+    end
+
+    it "persists the norwegian locale" do
+      expect(page.reload.localize("nb").name.to_s).to eq("Tittel")
+    end
+  end
+
+  describe "updating an existing localization" do
+    let(:page) { Page.create(name: "Title", locale: "en") }
+
+    it "updates the value" do
+      page.update!(name: "Changed")
+      expect(page.reload.name.to_s).to eq("Changed")
+    end
+
+    it "does not insert a duplicate" do
+      page.update!(name: "Changed")
+      expect(Localization.where(localizable: page, name: "name").count).to eq(1)
+    end
+  end
+
+  describe "clearing a localization" do
+    let(:page) { Page.create(name: "Title", locale: "en") }
+
+    it "removes the localization" do
+      page.update!(name: "")
+      expect(Localization.where(localizable: page, name: "name")).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Localizations are persisted via an autosave `has_many` association, inside the parent model's save transaction. When two saves concurrently create the same localization — i.e. the same `(localizable_id, localizable_type, name, locale)` key — the second `INSERT` violates `index_localizations_on_locale` and raises `ActiveRecord::RecordNotUnique`. Because the violation happens inside the transaction, Postgres aborts the whole save, so the failure surfaces as an unhandled error rather than something the gem can recover from in place.

## Fix

Persist localizations explicitly instead of relying on autosave:

- `has_many :localizations` is now `autosave: false`, and a `before_save :cleanup_localizations!` becomes `after_save :save_localizations!`.
- `save_localizations!` writes new/changed values with `upsert_all` (`INSERT … ON CONFLICT DO UPDATE`), so concurrent creation of the same key resolves to last-write-wins instead of raising.
- Emptied localizations are deleted, and the parent's `updated_at` touch behaviour is preserved (only when localizations actually changed and the parent row wasn't otherwise written).

`upsert_all`'s conflict target requires a unique index on the key columns. The generator template and the test schema/migration previously created `index_localizations_on_locale` as **non-unique**; they now create it `unique: true`.

## Compatibility

Existing apps whose `localizations` table already has the unique index (e.g. those created by pages_core's migration) work unchanged. An app that built the table from this gem's old generator has a non-unique index and must dedupe rows and add the unique index before upgrading, otherwise `upsert_all` raises `ArgumentError` (no matching unique constraint).

## Tests

- New `spec/models/localizable_persistence_spec.rb` reproduces the duplicate-key race (stale in-memory collection + an externally-created row) and covers multi-locale save, in-place update, and clearing. The race example raised `RecordNotUnique` before the fix and passes after.
- Full suite green (50 examples, 0 failures); RuboCop clean.
