### PR TITLE
fix: do not report blank locale for phantom localizations

### DIFF
--- a/lib/localizable_model/localizer.rb
+++ b/lib/localizable_model/localizer.rb
@@ -12,7 +12,7 @@ module LocalizableModel
     delegate :attribute?, to: :@configuration
 
     def locales
-      @model.localizations.map(&:locale).uniq
+      @model.localizations.map(&:locale).compact_blank.uniq
     end
 
     def locale?
@@ -57,12 +57,14 @@ module LocalizableModel
       records    = @model.localizations.target
       removable  = records.select { |l| l.persisted? && !l.value? }
       upsertable = records.select { |l| upsertable?(l) }
-      return if removable.empty? && upsertable.empty?
 
-      delete_localizations(removable)
-      upsert_localizations(upsertable)
+      unless removable.empty? && upsertable.empty?
+        delete_localizations(removable)
+        upsert_localizations(upsertable)
+        touch_localizable
+      end
+
       @model.association(:localizations).reset
-      touch_localizable
     end
 
     private

--- a/spec/models/localizable_persistence_spec.rb
+++ b/spec/models/localizable_persistence_spec.rb
@@ -71,4 +71,21 @@ describe "LocalizablePersistence" do
       expect(Localization.where(localizable: page, name: "name")).to be_empty
     end
   end
+
+  describe "reading a localized attribute without assigning a locale" do
+    let(:page) { Page.new }
+
+    before do
+      page.name?
+      page.save!
+    end
+
+    it "does not report a blank locale" do
+      expect(page.locales).to eq([])
+    end
+
+    it "does not persist a phantom localization" do
+      expect(Localization.where(localizable: page)).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
## Problem

v0.6.7 (`fb9a287`, the upsert change) introduced a regression in `Localizer#locales`. For a record where a localized attribute was *read* but no locale was ever assigned, `record.locales` now returns `[""]` instead of `[]` after saving.

```ruby
p = Page.new
p.name?    # reading any localized attribute is enough
p.save
p.locales  # 0.6.6 => []   |   0.6.7 => [""]
```

### Mechanism

1. Attribute getters call `Localizer#get`, which builds an in-memory localization with `locale: localizer.locale.to_s` — `""` when no locale is set.
2. `Localizer#locales` was `@model.localizations.map(&:locale).uniq`, so it included that blank locale.
3. In 0.6.6 the phantom blank-locale record never survived a save (the old `cleanup_localizations!` + autosave reset removed it).
4. In 0.6.7 `save_localizations!` early-returns when there is nothing to upsert/delete, *before* resetting the association, so the in-memory phantom lingers and `locales` reports `""`.

This breaks downstream consumers that iterate `record.locales` (e.g. a search indexer creating a record per locale with `validates :locale, presence: true`), which can raise inside an `after_save` and roll back the whole save.

## Fix

- `#locales` filters blank locales (`compact_blank`), so a phantom blank-locale record can never surface — even when a getter rebuilds one *after* save (which is exactly what happens when a later `after_save` callback reads a localized attribute).
- `save_localizations!` always resets the association, including the no-op early-return path, dropping phantom in-memory records on every save and restoring the 0.6.6 invariant.

## Tests

Added a regression spec asserting that reading a localized attribute without assigning a locale and then saving leaves `locales == []` with no persisted localization. Verified it fails on the pre-fix code (`[""]`) and passes with the fix. Full suite green; rubocop clean.